### PR TITLE
Round Win% stat

### DIFF
--- a/src/pages/stats/[userId].tsx
+++ b/src/pages/stats/[userId].tsx
@@ -166,9 +166,9 @@ export default function Stats({
             {row(
               "Win% ratio",
               (
-                ((liveUserScores.total_games - liveUserScores.total_losses) /
+                Math.round((((liveUserScores.total_games - liveUserScores.total_losses) /
                   liveUserScores.total_games) *
-                100
+                100) * 100) / 100
               ).toString() + "%"
             )}
 


### PR DESCRIPTION
Rounds the Win Percentage statistic to the nearest hundredth (As described in [https://github.com/zachpmanson/minecraftle/issues/45](https://github.com/zachpmanson/minecraftle/issues/45)).