### PR TITLE
Rename confusing star button to something that describes what it actually does

### DIFF
--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -51,7 +51,7 @@ export default function Layout({ children }: any) {
                       })
                     }
                   >
-                    <div className="px-4">☼</div>
+                    <div className="px-4">Colourblind Mode</div>
                   </MCButton>
                 </div>
                 {/* </div> */}


### PR DESCRIPTION
First thing I did was click on every button to see what it did, before getting into the game itself. The star button seemed to do nothing.
But apparently I was just supposed to know that it toggles the colorblind mode which turns green into orange and orange into blue.

This pull request renames the button to describe its function, because users are not telepathic and are easily frustrated.

(Even then, you should really make it do something visible when clicked if you don't already have a game in progress, and make it possible to see whether it's active or not, but I don't know typescript so I'll leave it to someone who does.)