### PR TITLE
Fix incorrect date listed in game summary

### DIFF
--- a/src/components/Popup.component.tsx
+++ b/src/components/Popup.component.tsx
@@ -24,11 +24,12 @@ export default function Popup({
     items,
     options: { highContrast },
     resetGame,
+    gameDate,
   } = useGlobal();
   const [copyButtonText, setCopyButtonText] = useState("Copy");
   console.log("highContrast", highContrast);
   const generateSummary = () => {
-    let summaryString = `Minecraftle ${new Date().toISOString().slice(0, 10)} ${
+    let summaryString = `Minecraftle ${new Date(gameDate.getTime() - gameDate.getTimezoneOffset() * 1000 * 60).toISOString().slice(0, 10)} ${
       craftingTables.length
     }/10\n`;
 


### PR DESCRIPTION
Two issues with the date, listed in the summary of a game, have been fixed:

1. It now represents the date of the puzzle, instead of the date of the summary's generation. That lead to an incorrect puzzle date being listed if a previously opened puzzle is played after midnight.
2. It's now converted to local time before it's printed, because `Date.toISOString()` always outputs the time in UTC.